### PR TITLE
Add option for custom mask character

### DIFF
--- a/maskformatter/src/main/java/com/azimolabs/maskformatter/MaskFormatter.java
+++ b/maskformatter/src/main/java/com/azimolabs/maskformatter/MaskFormatter.java
@@ -11,9 +11,9 @@ public class MaskFormatter implements TextWatcher {
 
     private static final char SPACE = ' ';
 
-    private String mask;
-
-    private EditText maskedField;
+    private final String mask;
+    private final EditText maskedField;
+    private final char maskCharacter;
 
     private boolean editTextChange;
     private int newIndex;
@@ -21,8 +21,13 @@ public class MaskFormatter implements TextWatcher {
     private int selectionBefore;
 
     public MaskFormatter(String mask, EditText maskedField) {
+        this(mask, maskedField, SPACE);
+    }
+
+    public MaskFormatter(String mask, EditText maskedField, char maskCharacter) {
         this.mask = mask;
         this.maskedField = maskedField;
+        this.maskCharacter = maskCharacter;
     }
 
     @Override
@@ -77,7 +82,7 @@ public class MaskFormatter implements TextWatcher {
         }
 
         if (selectionBefore - 1 >= 0
-            && appliedMaskString.charAt(selectionBefore - 1) == SPACE) {
+            && appliedMaskString.charAt(selectionBefore - 1) == maskCharacter) {
             return selectionBefore - 1;
         }
 
@@ -89,7 +94,7 @@ public class MaskFormatter implements TextWatcher {
             return appliedMaskString.length();
         }
 
-        if (appliedMaskString.charAt(selectionBefore) == SPACE) {
+        if (appliedMaskString.charAt(selectionBefore) == maskCharacter) {
             return selectionBefore + 2;
         }
 
@@ -105,15 +110,15 @@ public class MaskFormatter implements TextWatcher {
     }
 
     private String applyMask(String newValue) throws InvalidTextException {
-        String newValueWithoutSpaces = newValue.replaceAll("\\s", "");
+        String newValueWithoutSpaces = newValue.replaceAll(String.valueOf(maskCharacter), "");
         StringBuilder sb = new StringBuilder();
         int index = 0;
         for (char c : newValueWithoutSpaces.toCharArray()) {
             if (index >= mask.length()) {
                 throw new InvalidTextException();
             }
-            while (mask.charAt(index) == SPACE) {
-                sb.append(SPACE);
+            while (mask.charAt(index) == maskCharacter) {
+                sb.append(maskCharacter);
                 index++;
             }
             sb.append(applyMaskToChar(c, index));
@@ -134,7 +139,7 @@ public class MaskFormatter implements TextWatcher {
         }
 
         char maskChar = getFirstNotWhiteCharFromMask();
-        if (maskChar == SPACE) {
+        if (maskChar == maskCharacter) {
             return;
         }
 
@@ -143,14 +148,13 @@ public class MaskFormatter implements TextWatcher {
 
     private char getFirstNotWhiteCharFromMask() {
         int maskIndex = maskedField.getSelectionEnd();
-        while (maskIndex < mask.length() && mask.charAt(maskIndex) == SPACE) {
+        while (maskIndex < mask.length() && mask.charAt(maskIndex) == maskCharacter) {
             maskIndex++;
         }
         return mask.charAt(maskIndex);
     }
 
     public String getRawTextValue() {
-        return maskedField.getText().toString().replaceAll("\\s", "");
+        return maskedField.getText().toString().replaceAll(String.valueOf(maskCharacter), "");
     }
-
 }

--- a/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
+++ b/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
@@ -1,15 +1,12 @@
 package com.azimolabs.maskformatter;
 
-import android.text.Editable;
 import android.text.InputType;
 import android.widget.EditText;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -209,6 +206,30 @@ public class MaskFormatterTests {
         filter.afterTextChanged(null);
 
         verify(mockEditText, never()).setInputType(anyInt());
+    }
+
+    @Test
+    public void testShouldSetProperInputTypeToTextWithDashesInMask() {
+        String mask = "123-456-7890";
+        filter = new MaskFormatter(mask, mockEditText, '-');
+
+        reset(mockEditText);
+        String fieldCurrentValue = "1";
+        when(mockEditText.getSelectionEnd()).thenReturn(fieldCurrentValue.length());
+
+        filter.afterTextChanged(null);
+
+        verify(mockEditText).setInputType(InputType.TYPE_CLASS_NUMBER);
+
+        // ---
+
+        reset(mockEditText);
+        fieldCurrentValue = "111-11-1111";
+        when(mockEditText.getSelectionEnd()).thenReturn(fieldCurrentValue.length());
+
+        filter.afterTextChanged(null);
+
+        verify(mockEditText).setInputType(InputType.TYPE_CLASS_NUMBER);
     }
 
 }

--- a/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
+++ b/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
@@ -210,7 +210,7 @@ public class MaskFormatterTests {
 
     @Test
     public void testShouldSetProperInputTypeToTextWithDashesInMask() {
-        String mask = "123-456-7890";
+        String mask = "999-999-9999";
         filter = new MaskFormatter(mask, mockEditText, '-');
 
         reset(mockEditText);

--- a/sampleapp/src/main/java/com/azimolabs/maskformatter/sampleapp/MainActivity.java
+++ b/sampleapp/src/main/java/com/azimolabs/maskformatter/sampleapp/MainActivity.java
@@ -14,22 +14,26 @@ public class MainActivity extends Activity {
 
     private static final String CHARS_MASK = "AAZZ aazz @@ww ##%%";
 
+    private static final String NUMBERS_DASHED_MASK = "999-999-9999";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        EditText ibanField = (EditText) findViewById(R.id.etIban);
-        MaskFormatter ibanFormatter = new MaskFormatter(IBAN_MASK, ibanField);
-        ibanField.addTextChangedListener(ibanFormatter);
-
-        EditText numbersField = (EditText) findViewById(R.id.etNumbers);
-        MaskFormatter numbersFormatter = new MaskFormatter(NUMBERS_MASK, numbersField);
-        numbersField.addTextChangedListener(numbersFormatter);
-
-        EditText charsField = (EditText) findViewById(R.id.etChars);
-        MaskFormatter charsFormatter = new MaskFormatter(CHARS_MASK, charsField);
-        charsField.addTextChangedListener(charsFormatter);
+        setupEditText(R.id.etIban, IBAN_MASK);
+        setupEditText(R.id.etNumbers, NUMBERS_MASK);
+        setupEditText(R.id.etChars, CHARS_MASK);
+        setupEditTextWithDashes(R.id.etDashedNumbers, NUMBERS_DASHED_MASK);
     }
 
+    private void setupEditText(int layoutId, String mask) {
+        EditText field = (EditText) findViewById(layoutId);
+        field.addTextChangedListener(new MaskFormatter(mask, field));
+    }
+
+    private void setupEditTextWithDashes(int layoutId, String mask) {
+        EditText field = (EditText) findViewById(layoutId);
+        field.addTextChangedListener(new MaskFormatter(mask, field, '-'));
+    }
 }

--- a/sampleapp/src/main/res/layout/activity_main.xml
+++ b/sampleapp/src/main/res/layout/activity_main.xml
@@ -45,4 +45,17 @@
         android:layout_height="wrap_content"
         android:inputType="text|textNoSuggestions"/>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/margin_small"
+        android:paddingTop="@dimen/margin_small"
+        android:text="@string/numbers_dashes_mask_hint"/>
+
+    <EditText
+        android:id="@+id/etDashedNumbers"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text|textNoSuggestions"/>
+
 </LinearLayout>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="iban_mask_hint">Field with mask: AA 9999 AAAA wwww wwww wwww</string>
     <string name="numbers_mask_hint">Field with mask: dd DD 1234 5678 90</string>
     <string name="chars_mask_hint">Field with mask: AAZZ aazz @@ww ##%%</string>
+    <string name="numbers_dashes_mask_hint">Field with mask: 999&#8211;999&#8211;9999</string>
 </resources>


### PR DESCRIPTION
This PR adds the ability to pass in a custom mask character to a second constructor. In the tests this character is a "-" and I use it for phone-number formatting in a project.

There is a minor change in functionality in `MaskFormatter`. I've changed:

```
replaceAll("\\s", "")
```

which is now replaced with:

```replaceAll(String.valueOf(maskCharacter), "")```

I'm not sure if there's a use case with the library where there is more than one white space character that needs to be replaced, let me know if so and I'll update this PR.

This PR addresses an open issue: #4. Let me know what you think, cheers!