### PR TITLE
Preserve password input type

### DIFF
--- a/maskformatter/src/main/java/com/azimolabs/maskformatter/MaskFormatter.java
+++ b/maskformatter/src/main/java/com/azimolabs/maskformatter/MaskFormatter.java
@@ -1,6 +1,8 @@
 package com.azimolabs.maskformatter;
 
+import android.os.Build;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.widget.EditText;
 
@@ -19,10 +21,26 @@ public class MaskFormatter implements TextWatcher {
     private int newIndex;
     private String textBefore;
     private int selectionBefore;
+    private int passwordMask;
 
     public MaskFormatter(String mask, EditText maskedField) {
         this.mask = mask;
         this.maskedField = maskedField;
+        this.passwordMask = getPasswordMask(maskedField);
+        setInputTypeBasedOnMask();
+    }
+
+    private int getPasswordMask(EditText maskedField) {
+        int inputType = maskedField.getInputType();
+        int maskedFieldPasswordMask = (inputType & InputType.TYPE_TEXT_VARIATION_PASSWORD
+            | inputType & InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+            maskedFieldPasswordMask |= inputType & InputType.TYPE_NUMBER_VARIATION_PASSWORD;
+            maskedFieldPasswordMask |= inputType & InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD;
+        }
+
+        return maskedFieldPasswordMask;
     }
 
     @Override
@@ -138,7 +156,7 @@ public class MaskFormatter implements TextWatcher {
             return;
         }
 
-        maskedField.setInputType(CharInputType.getKeyboardTypeForNextChar(maskChar));
+        maskedField.setInputType(passwordMask | CharInputType.getKeyboardTypeForNextChar(maskChar));
     }
 
     private char getFirstNotWhiteCharFromMask() {

--- a/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
+++ b/maskformatter/src/test/java/com/azimolabs/maskformatter/MaskFormatterTests.java
@@ -1,18 +1,16 @@
 package com.azimolabs.maskformatter;
 
-import android.text.Editable;
 import android.text.InputType;
 import android.widget.EditText;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -211,4 +209,46 @@ public class MaskFormatterTests {
         verify(mockEditText, never()).setInputType(anyInt());
     }
 
+    @Test
+    public void testShouldSetProperInputTypeToPassword() {
+        when(mockEditText.getInputType()).thenReturn(InputType.TYPE_TEXT_VARIATION_PASSWORD
+            | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+
+        String mask = "99 AAAA wwww wwww wwww wwww";
+        filter = new MaskFormatter(mask, mockEditText);
+
+        String fieldCurrentValue = "99";
+        when(mockEditText.getSelectionEnd()).thenReturn(fieldCurrentValue.length());
+
+        filter.afterTextChanged(null);
+
+        verify(mockEditText).setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_TEXT_VARIATION_PASSWORD
+            | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+
+        // ---
+
+        fieldCurrentValue = "99 ABCD";
+        reset(mockEditText);
+        when(mockEditText.getSelectionEnd()).thenReturn(fieldCurrentValue.length());
+
+        filter.afterTextChanged(null);
+
+        verify(mockEditText).setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD
+            | InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD);
+    }
+
+    @Test
+    public void testShouldSetProperInputTypeToNumberPassword() {
+        when(mockEditText.getInputType()).thenReturn(InputType.TYPE_TEXT_VARIATION_PASSWORD);
+
+        String mask = "999 99 9999";
+        filter = new MaskFormatter(mask, mockEditText);
+
+        String fieldCurrentValue = "123";
+        when(mockEditText.getSelectionEnd()).thenReturn(fieldCurrentValue.length());
+
+        filter.afterTextChanged(null);
+
+        verify(mockEditText, times(2)).setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+    }
 }

--- a/sampleapp/src/main/java/com/azimolabs/maskformatter/sampleapp/MainActivity.java
+++ b/sampleapp/src/main/java/com/azimolabs/maskformatter/sampleapp/MainActivity.java
@@ -14,22 +14,21 @@ public class MainActivity extends Activity {
 
     private static final String CHARS_MASK = "AAZZ aazz @@ww ##%%";
 
+    private static final String NUMBERS_MASKED_MASK = "999 99 9999";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        EditText ibanField = (EditText) findViewById(R.id.etIban);
-        MaskFormatter ibanFormatter = new MaskFormatter(IBAN_MASK, ibanField);
-        ibanField.addTextChangedListener(ibanFormatter);
-
-        EditText numbersField = (EditText) findViewById(R.id.etNumbers);
-        MaskFormatter numbersFormatter = new MaskFormatter(NUMBERS_MASK, numbersField);
-        numbersField.addTextChangedListener(numbersFormatter);
-
-        EditText charsField = (EditText) findViewById(R.id.etChars);
-        MaskFormatter charsFormatter = new MaskFormatter(CHARS_MASK, charsField);
-        charsField.addTextChangedListener(charsFormatter);
+        setupEditText(R.id.etIban, IBAN_MASK);
+        setupEditText(R.id.etNumbers, NUMBERS_MASK);
+        setupEditText(R.id.etChars, CHARS_MASK);
+        setupEditText(R.id.ssnChars, NUMBERS_MASKED_MASK);
     }
 
+    private void setupEditText(int layoutId, String mask) {
+        EditText field = (EditText) findViewById(layoutId);
+        field.addTextChangedListener(new MaskFormatter(mask, field));
+    }
 }

--- a/sampleapp/src/main/res/layout/activity_main.xml
+++ b/sampleapp/src/main/res/layout/activity_main.xml
@@ -45,4 +45,17 @@
         android:layout_height="wrap_content"
         android:inputType="text|textNoSuggestions"/>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="@dimen/margin_small"
+        android:paddingTop="@dimen/margin_small"
+        android:text="@string/password_mask_hint"/>
+
+    <EditText
+        android:id="@+id/ssnChars"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="text|textNoSuggestions|numberPassword"/>
+
 </LinearLayout>

--- a/sampleapp/src/main/res/values/strings.xml
+++ b/sampleapp/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="iban_mask_hint">Field with mask: AA 9999 AAAA wwww wwww wwww</string>
     <string name="numbers_mask_hint">Field with mask: dd DD 1234 5678 90</string>
     <string name="chars_mask_hint">Field with mask: AAZZ aazz @@ww ##%%</string>
+    <string name="password_mask_hint">Password field with mask: 999 99 9999</string>
 </resources>


### PR DESCRIPTION
If I set an `EditText` to have an input-type of `numberPassword` or `textPassword` I want the "dot masking" to be preserved. Right now the `setInputTypeBasedOnMask` method removes the dot masking. (See the GIFs below for a demo on an emulator). This fixes issue #9.

My use case for this is masking a user's social security number in an app (for which I use it in combination with PR #6 which added dashes as a replacement for the space character).

If a user enters the social security number: "123-45-6789" it masks the numbers and the dashes.

It's not an ideal way of doing things because I don't want to see the dashes or spaces masked with the numbers, but I'd need to use a custom component to handle that and it's not in the scope of this library or this PR. 

But it works for the app I use it in.

This may be a special use case and may not fit the intent of this library, but let me know what you think, thanks!

Problem: The `EditText` has a password on the input-type (see `activity_main.xml`).
![problem](https://cloud.githubusercontent.com/assets/1313555/22180988/766e63a4-e036-11e6-8e87-5776304f0436.gif)

Fix: Any variation of `InputType.PASSWORD` is preserved.
![preserving-password](https://cloud.githubusercontent.com/assets/1313555/22180987/766e373a-e036-11e6-9d0e-2da4fbfca0bc.gif)